### PR TITLE
Ftr closable

### DIFF
--- a/src/main/scala/io/plasmap/parser/OsmParser.scala
+++ b/src/main/scala/io/plasmap/parser/OsmParser.scala
@@ -7,7 +7,9 @@ import scala.io.Codec
 import scala.io.Source
 import impl._
 
-trait OsmParser extends Iterator[Option[OsmObject]]
+trait OsmParser extends Iterator[Option[OsmObject]] {
+  def close()
+}
 
 object OsmParser {
 

--- a/src/main/scala/io/plasmap/parser/impl/OsmPbfParser.scala
+++ b/src/main/scala/io/plasmap/parser/impl/OsmPbfParser.scala
@@ -55,7 +55,7 @@ case class OsmPbfParser (fileName: String)  extends OsmParser{
 
   val osmObjects = mutable.Queue[Option[OsmObject]]()
 
-
+  override def close() = dis.close()
 
   override def hasNext: Boolean =
     dis.available() != 0 || osmObjects.nonEmpty

--- a/src/main/scala/io/plasmap/parser/impl/OsmXmlParser.scala
+++ b/src/main/scala/io/plasmap/parser/impl/OsmXmlParser.scala
@@ -24,7 +24,10 @@ case class OsmXmlParser(source: Source) extends OsmParser {
 
   val reader = new XMLEventReader(source)
 
-  override def close() = source.close()
+  override def close() = {
+    reader.stop()
+    source.close()
+  }
 
   override def hasNext() = reader.hasNext
 

--- a/src/main/scala/io/plasmap/parser/impl/OsmXmlParser.scala
+++ b/src/main/scala/io/plasmap/parser/impl/OsmXmlParser.scala
@@ -24,6 +24,8 @@ case class OsmXmlParser(source: Source) extends OsmParser {
 
   val reader = new XMLEventReader(source)
 
+  override def close() = source.close()
+
   override def hasNext() = reader.hasNext
 
   override def next(): Option[OsmObject] = {
@@ -110,7 +112,6 @@ case class OsmXmlParser(source: Source) extends OsmParser {
     }
     result
   }
-
 
 }
 


### PR DESCRIPTION
I added a close() method to the OsmParser Trait and implemented it in the OsmXmlParser and the OsmPbfParser.

The OsmPbfParser will forward this call to it's DataInputStream.

And the OsmXmlParser will forward it to its Source that will forward it to its FileInputStream as can be seen in the source code: https://github.com/scala/scala/blob/v2.11.7/src/library/scala/io/Source.scala#L97

Demonstration. This code won't explode anymore:
```
~/geow$ sbt console
scala> import io.plasmap.parser._

scala>(0 to 4000).foreach( x => {val p = OsmParser("./duesseldorf-regbez-latest.osm.pbf"); p.close()} )
```